### PR TITLE
fix: Correct run command in README for package execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ This project is a Python-based SOCKS5 proxy designed for Windows that provides i
 
 ## How to Run
 
-To run the proxy and the monitoring dashboard, execute the main script from the root directory:
+To run the proxy and the monitoring dashboard, execute the main script **from the project's root directory** using Python's `-m` flag to ensure the package is loaded correctly:
 
 ```sh
-python3 netmix/main.py
+python -m netmix.main
 ```
+(Use `python3` if that is your default interpreter)
 
 - The proxy server will start listening on `127.0.0.1:1080`.
 - The terminal will display the live monitoring dashboard.


### PR DESCRIPTION
This commit fixes the instructions in README.md to use the correct method for running a Python package as a script (`python -m netmix.main`).

The previous instruction (`python netmix/main.py`) would fail with a `ModuleNotFoundError` because it doesn't correctly add the project's root directory to the Python path, preventing absolute imports within the package. Using the `-m` flag is the standard and correct way to execute a module within a package, and it resolves this issue.