### PR TITLE
fix: Correctly initialize asyncio event loop with curses

### DIFF
--- a/netmix/main.py
+++ b/netmix/main.py
@@ -170,8 +170,13 @@ if __name__ == '__main__':
         filemode='w'
     )
 
+    def start_app(stdscr):
+        """Sync wrapper to launch the asyncio event loop."""
+        asyncio.run(main(stdscr))
+
     try:
-        curses.wrapper(main)
+        # curses.wrapper takes a sync function, which in turn runs our async code.
+        curses.wrapper(start_app)
     except KeyboardInterrupt:
         logging.info("Program interrupted by user.")
     finally:


### PR DESCRIPTION
This commit resolves a `RuntimeWarning: coroutine 'main' was never awaited`.

The issue was caused by passing an `async def` function directly to `curses.wrapper`, which is a synchronous function and does not know how to await a coroutine. This caused the program to exit immediately after starting, without running the main asyncio event loop.

The fix introduces a new synchronous function, `start_app`, which is passed to `curses.wrapper`. This `start_app` function is then responsible for starting the asyncio event loop by calling `asyncio.run(main(stdscr))`. This is the standard pattern for integrating `curses` with `asyncio` and ensures the application runs as intended.