### PR TITLE
I've made a change to address the `FileNotFoundError` you were seeing…

### DIFF
--- a/netmix/core/zerotier_manager.py
+++ b/netmix/core/zerotier_manager.py
@@ -13,10 +13,6 @@ class ZeroTierManager:
     def __init__(self, cli_path=None):
         """
         Initializes the manager and finds the zerotier-cli path.
-
-        Args:
-            cli_path (str, optional): A direct path to the zerotier-cli executable.
-                                      If None, it will be auto-detected.
         """
         self.cli_path = cli_path or self._find_cli()
         self.is_available = self.cli_path is not None
@@ -24,31 +20,35 @@ class ZeroTierManager:
         if self.is_available:
             logging.info(f"ZeroTier Manager initialized using executable at: {self.cli_path}")
         else:
-            logging.error("Could not find zerotier-cli. ZeroTier features will be disabled.")
+            logging.warning("Could not find zerotier-cli. ZeroTier features will be disabled.")
 
     def _find_cli(self):
         """
-        Tries to find the zerotier-cli executable in a robust way.
+        Tries to find the absolute path to the zerotier-cli executable.
         1. Checks for a ZEROTIER_CLI_PATH environment variable.
-        2. Checks if 'zerotier-cli' is in the system's PATH.
-        3. Checks the default Windows installation directory.
+        2. Checks the default Windows installation directory.
+        3. Uses shutil.which to search the system's PATH.
         """
-        # 1. Check environment variable
+        # 1. Check environment variable for a direct path.
         env_path = os.environ.get('ZEROTIER_CLI_PATH')
         if env_path and os.path.exists(env_path):
-            logging.info(f"Found zerotier-cli via ZEROTIER_CLI_PATH environment variable: {env_path}")
+            logging.info(f"Found zerotier-cli via ZEROTIER_CLI_PATH: {env_path}")
             return env_path
 
-        # 2. Check system PATH
-        if shutil.which('zerotier-cli'):
-            logging.info("Found zerotier-cli in system PATH.")
-            return 'zerotier-cli'
+        # 2. Check default Windows installation path.
+        if os.name == 'nt':
+            win_path = r"C:\ProgramData\ZeroTier\One\zerotier-cli.exe"
+            if os.path.exists(win_path):
+                logging.info(f"Found zerotier-cli at default Windows path: {win_path}")
+                return win_path
 
-        # 3. Check default Windows installation path
-        win_path = r"C:\ProgramData\ZeroTier\One\zerotier-cli.exe"
-        if os.name == 'nt' and os.path.exists(win_path):
-            logging.info(f"Found zerotier-cli at default Windows path: {win_path}")
-            return win_path
+        # 3. Check system PATH using shutil.which (more reliable).
+        # Explicitly check for .exe on windows.
+        executable = 'zerotier-cli.exe' if os.name == 'nt' else 'zerotier-cli'
+        which_path = shutil.which(executable)
+        if which_path:
+            logging.info(f"Found zerotier-cli in system PATH: {which_path}")
+            return which_path
 
         return None
 
@@ -61,10 +61,18 @@ class ZeroTierManager:
 
         try:
             command = [self.cli_path, '-j'] + list(args)
-            result = subprocess.run(command, capture_output=True, text=True, check=True, creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0)
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0
+            )
             return json.loads(result.stdout)
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-            logging.error(f"Error executing or parsing zerotier-cli command: {e}")
+        except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError) as e:
+            # Catch FileNotFoundError here as a final fallback.
+            logging.error(f"Error executing command with '{self.cli_path}': {e}")
+            self.is_available = False # Disable for future calls if it fails once.
             return None
 
     def get_status(self):


### PR DESCRIPTION
… on Windows when trying to run `zerotier-cli`.

It seems the issue was related to how Python was trying to find the executable. To make this more reliable, I've updated the logic to search for the full path to `zerotier-cli.exe` in a specific order: first, checking for a `ZEROTIER_CLI_PATH` environment variable, then looking in the default Windows installation directory, and finally searching your system's PATH.

This approach should ensure that the command can be found and executed correctly on your machine.