### PR TITLE
feat(zerotier): Implement automatic network join on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ ZT_API="http://127.0.0.1:9993"
 # This can be found in C:\ProgramData\ZeroTier\One\authtoken.secret on Windows.
 # If this is left blank, the agent will try to read it from the file automatically.
 ZT_TOKEN=""
+
+# The 16-character ID of the ZeroTier network you want to automatically join on startup.
+# If left blank, the application will not attempt to join a network.
+ZEROTIER_NETWORK_ID="E4DA7455B2A69F9A"

--- a/devlog.md
+++ b/devlog.md
@@ -29,3 +29,10 @@ With the core proxy functionality in place, the project was restructured for gre
 - **ML-Powered Routing:** A full pipeline for optional machine learning-based routing was implemented. The `ConnectionManager` logs training data, a `train.py` script builds a model, and the `AIPredictor` uses the trained model if available.
 - **Packaging:** A `netmix.spec` file was created to allow for easy packaging of the entire application into a standalone Windows executable using PyInstaller.
 - **ZeroTier API Integration:** The initial `zerotier-cli` wrapper was replaced with a much more robust `ZeroTierAPI` agent that communicates directly with the ZeroTier One local REST API, removing PATH dependencies and improving stability.
+
+## 2025-08-01: Phase 3 - Network Bonding and Advanced Features
+
+This phase begins the work on the most advanced features, starting with the foundational step of connecting to a virtual network to enable future bonding experiments.
+
+### Key Accomplishments:
+- **ZeroTier Auto-Join:** The application can now be configured with a `ZEROTIER_NETWORK_ID` in the `.env` file. On startup, it will automatically send a request to join this network, enabling persistent virtual network presence.

--- a/netmix/main.py
+++ b/netmix/main.py
@@ -51,6 +51,16 @@ def main_sync():
     proxy = SocksProxy('127.0.0.1', 1080, conn_manager, predictor)
     try:
         zt_api = ZeroTierAPI()
+        # Attempt to join the configured network on startup
+        network_to_join = os.getenv('ZEROTIER_NETWORK_ID')
+        if network_to_join:
+            logging.info(f"Attempting to join configured ZeroTier network: {network_to_join}")
+            try:
+                zt_api.join_network(network_to_join)
+                logging.info(f"Successfully sent request to join network {network_to_join}.")
+            except Exception as join_error:
+                logging.error(f"Failed to join network {network_to_join}: {join_error}")
+
     except Exception as e:
         logging.error(f"Failed to initialize ZeroTier API: {e}. Continuing without it.")
         zt_api = None


### PR DESCRIPTION
This commit introduces the first feature of Phase 3: the ability for the application to automatically join a specified ZeroTier network upon initialization.

- A new `ZEROTIER_NETWORK_ID` configuration variable has been added. It is loaded from the `.env` file.
- The main application runner in `netmix/main.py` now checks for this variable and, if present, calls the `zt_api.join_network()` method.
- Error handling has been added to gracefully manage failures during the join attempt.
- The `.env.example` and `devlog.md` files have been updated to reflect this new feature.

This provides the foundational capability needed to begin experimenting with routing and bonding over ZeroTier virtual networks.