### PR TITLE
fix(zerotier): Use local import as debug step for NameError

### DIFF
--- a/netmix/agent/zerotier_api.py
+++ b/netmix/agent/zerotier_api.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import requests
 from dotenv import load_dotenv
@@ -20,6 +19,7 @@ class ZeroTierAPI:
         Pulls configuration from environment variables by default, but can be
         overridden with direct arguments.
         """
+        import os # Local import for debugging
         self.api_url = api_url or os.getenv('ZT_API', 'http://127.0.0.1:9993')
         self._auth_token = auth_token or os.getenv('ZT_TOKEN')
 
@@ -35,6 +35,7 @@ class ZeroTierAPI:
 
     def _load_token_from_file(self):
         """Loads the auth token from the default location on Windows."""
+        import os # Local import for debugging
         if os.name != 'nt':
             return None # This path is specific to Windows
 


### PR DESCRIPTION
This commit attempts to fix a persistent `NameError: name 'os' is not defined` in the `ZeroTierAPI` agent, even when the `import os` statement was present at the top of the file.

As a debugging measure to work around a potential environment or module loading issue, I moved the `import os` statement to be local within the methods that require it (`__init__` and `_load_token_from_file`).

This is a non-standard practice but aims to ensure the `os` module is loaded into the function's scope at the time of execution, which should definitively resolve the `NameError`.