### PR TITLE
fix: Import os module in main.py

### DIFF
--- a/netmix/main.py
+++ b/netmix/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import threading
 import curses
 


### PR DESCRIPTION
The application was failing to initialize the ZeroTier API because the `os` module was used in `netmix/main.py` without being imported. This resulted in a `NameError` which was caught and logged.

This change adds the missing `import os` statement, allowing the ZeroTier integration to be initialized correctly.